### PR TITLE
Refactor dependencies

### DIFF
--- a/web-is-api/pom.xml
+++ b/web-is-api/pom.xml
@@ -15,10 +15,5 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>cz.muni.fi.pa165.monster-slayers</groupId>
-            <artifactId>web-is-persistence</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
     </dependencies>
 </project>

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/ClientRequestDTO.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/ClientRequestDTO.java
@@ -1,8 +1,5 @@
 package cz.muni.fi.pa165.monsterslayers.dto;
 
-import cz.muni.fi.pa165.monsterslayers.entities.ClientRequest;
-import cz.muni.fi.pa165.monsterslayers.entities.MonsterType;
-
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +16,7 @@ public class ClientRequestDTO {
     private UserDTO client;
     private String location;
     private String description;
-    private Map<MonsterType, Integer> killList = new HashMap<>();
+    private Map<MonsterTypeDTO, Integer> killList = new HashMap<>();
     private BigDecimal reward;
 
     public Long getId() {
@@ -63,11 +60,11 @@ public class ClientRequestDTO {
         this.description = description;
     }
 
-    public void addToKillList(MonsterType monsterType, int count){
+    public void addToKillList(MonsterTypeDTO monsterType, int count){
         killList.put(monsterType, count);
     }
 
-    public void removeFromKillList(MonsterType monsterType){
+    public void removeFromKillList(MonsterTypeDTO monsterType){
         killList.remove(monsterType);
     }
 
@@ -85,9 +82,9 @@ public class ClientRequestDTO {
             return true;
         if (obj == null)
             return false;
-        if (!(obj instanceof ClientRequest))
+        if (!(obj instanceof ClientRequestDTO))
             return false;
-        ClientRequest other = (ClientRequest) obj;
+        ClientRequestDTO other = (ClientRequestDTO) obj;
         return (Objects.equals(this.title, other.getTitle()));
     }
 

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/CreateClientRequestDTO.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/CreateClientRequestDTO.java
@@ -1,8 +1,5 @@
 package cz.muni.fi.pa165.monsterslayers.dto;
 
-import cz.muni.fi.pa165.monsterslayers.entities.MonsterType;
-import org.hibernate.validator.constraints.NotEmpty;
-
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -30,8 +27,9 @@ public class CreateClientRequestDTO {
     @Size(min = 4, max = 256)
     private String description;
 
-    @NotEmpty
-    private Map<MonsterType, Integer> killList = new HashMap<>();
+    //TODO: there cannot be dependency on Hibernate!
+    //@NotEmpty
+    private Map<MonsterTypeDTO, Integer> killList = new HashMap<>();
 
     @NotNull
     @Min(100)
@@ -69,11 +67,11 @@ public class CreateClientRequestDTO {
         this.description = description;
     }
 
-    public Map<MonsterType, Integer> getKillList() {
+    public Map<MonsterTypeDTO, Integer> getKillList() {
         return killList;
     }
 
-    public void setKillList(Map<MonsterType, Integer> killList) {
+    public void setKillList(Map<MonsterTypeDTO, Integer> killList) {
         this.killList = killList;
     }
 

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/CreateHeroDTO.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/CreateHeroDTO.java
@@ -1,11 +1,10 @@
 package cz.muni.fi.pa165.monsterslayers.dto;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 import java.util.Collection;
 import java.util.HashSet;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import org.hibernate.validator.constraints.NotEmpty;
 /**
  * Data transfer object for creating hero to specified user.
  *
@@ -18,7 +17,8 @@ public class CreateHeroDTO {
     @Size(min = 4, max = 32)
     private String heroName;
 
-    @NotEmpty(message = "Hero should control at least one power element. Otherwise, it's not a true hero :).")
+    //TODO: we cannot have Hibernate dependency here
+//    @NotEmpty(message = "Hero should control at least one power element. Otherwise, it's not a true hero :).")
     private Collection<PowerElement> elements = new HashSet<>();
 
     public CreateHeroDTO(Long userId, String heroName) {

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/CreateMonsterTypeDTO.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/CreateMonsterTypeDTO.java
@@ -1,6 +1,6 @@
 package cz.muni.fi.pa165.monsterslayers.dto;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 
 /**
  * DTO for creating a new MonsterType.

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/HeroDTO.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/HeroDTO.java
@@ -1,6 +1,6 @@
 package cz.muni.fi.pa165.monsterslayers.dto;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/MonsterTypeDTO.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/MonsterTypeDTO.java
@@ -1,6 +1,6 @@
 package cz.muni.fi.pa165.monsterslayers.dto;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/UserDTO.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/dto/UserDTO.java
@@ -1,28 +1,28 @@
 package cz.muni.fi.pa165.monsterslayers.dto;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.RightsLevel;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.UserStatus;
+import cz.muni.fi.pa165.monsterslayers.enums.RightsLevel;
+import cz.muni.fi.pa165.monsterslayers.enums.UserStatus;
 import java.util.Objects;
 
 /**
  * Basic data transfer object for user
- * 
+ *
  * @author Tomáš Richter
  */
 public class UserDTO {
     private Long id;
     private String name;
     private String email;
-    
+
     //hash of the password
     private String password;
-    
+
     private byte[] image;
     private String imageMimeType;
 
     private UserStatus status;
     private RightsLevel rightsLevel;
-    
+
     public Long getId() {
         return id;
     }
@@ -86,7 +86,7 @@ public class UserDTO {
     public void setRightsLevel(RightsLevel rightsLevel) {
         this.rightsLevel = rightsLevel;
     }
-    
+
     @Override
     public boolean equals(Object o) {
         if (o == null) {

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/enums/JobStatus.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/enums/JobStatus.java
@@ -1,8 +1,8 @@
-package cz.muni.fi.pa165.monsterslayers.entities.enums;
+package cz.muni.fi.pa165.monsterslayers.enums;
 
 /**
  * Enumeration of possible statuses of a Job
- * 
+ *
  * @author Tomáš Richter
  */
 public enum JobStatus {

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/enums/PowerElement.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/enums/PowerElement.java
@@ -1,4 +1,4 @@
-package cz.muni.fi.pa165.monsterslayers.entities.enums;
+package cz.muni.fi.pa165.monsterslayers.enums;
 
 /**
  * Enumerates elements that can be used to defeat a monster.

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/enums/RightsLevel.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/enums/RightsLevel.java
@@ -1,4 +1,4 @@
-package cz.muni.fi.pa165.monsterslayers.entities.enums;
+package cz.muni.fi.pa165.monsterslayers.enums;
 
 /**
  * Enumerates levels of rights that a User can have. These are used to validate access to certain parts of the system.

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/enums/UserStatus.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/enums/UserStatus.java
@@ -1,4 +1,4 @@
-package cz.muni.fi.pa165.monsterslayers.entities.enums;
+package cz.muni.fi.pa165.monsterslayers.enums;
 
 /**
  * Enumerates statuses that a User can be in.

--- a/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/facade/MonsterTypeFacade.java
+++ b/web-is-api/src/main/java/cz/muni/fi/pa165/monsterslayers/facade/MonsterTypeFacade.java
@@ -3,7 +3,6 @@ package cz.muni.fi.pa165.monsterslayers.facade;
 import cz.muni.fi.pa165.monsterslayers.dto.CreateMonsterTypeDTO;
 import cz.muni.fi.pa165.monsterslayers.dto.ModifyMonsterTypeDTO;
 import cz.muni.fi.pa165.monsterslayers.dto.MonsterTypeDTO;
-import cz.muni.fi.pa165.monsterslayers.entities.MonsterType;
 
 /**
  * Facade layer interface for MonsterType.

--- a/web-is-persistence/pom.xml
+++ b/web-is-persistence/pom.xml
@@ -17,6 +17,11 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <dependencies>
+        <dependency>
+            <groupId>cz.muni.fi.pa165.monster-slayers</groupId>
+            <artifactId>web-is-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
 
         <!-- JUnit -->
         <!--<dependency>

--- a/web-is-persistence/src/main/java/cz/muni/fi/pa165/monsterslayers/entities/Hero.java
+++ b/web-is-persistence/src/main/java/cz/muni/fi/pa165/monsterslayers/entities/Hero.java
@@ -1,6 +1,6 @@
 package cz.muni.fi.pa165.monsterslayers.entities;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -95,7 +95,7 @@ public class Hero {
         }
         return Objects.equals(this.user, other.getUser());
     }
-    
+
     @Override
     public int hashCode() {
         int hash = 7;

--- a/web-is-persistence/src/main/java/cz/muni/fi/pa165/monsterslayers/entities/Job.java
+++ b/web-is-persistence/src/main/java/cz/muni/fi/pa165/monsterslayers/entities/Job.java
@@ -1,6 +1,7 @@
 package cz.muni.fi.pa165.monsterslayers.entities;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.JobStatus;
+import cz.muni.fi.pa165.monsterslayers.enums.JobStatus;
+
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.*;
@@ -37,8 +38,8 @@ public class Job {
     public Job(ClientRequest clientRequest, Hero assignee) {
         this.clientRequest = clientRequest;
         this.assignee = assignee;
-    } 
-    
+    }
+
     public Long getId() {
         return id;
     }
@@ -103,5 +104,5 @@ public class Job {
             return false;
         }
         return (Objects.equals(this.assignee, other.getAssignee()));
-    } 
+    }
 }

--- a/web-is-persistence/src/main/java/cz/muni/fi/pa165/monsterslayers/entities/MonsterType.java
+++ b/web-is-persistence/src/main/java/cz/muni/fi/pa165/monsterslayers/entities/MonsterType.java
@@ -1,6 +1,6 @@
 package cz.muni.fi.pa165.monsterslayers.entities;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;

--- a/web-is-persistence/src/main/java/cz/muni/fi/pa165/monsterslayers/entities/User.java
+++ b/web-is-persistence/src/main/java/cz/muni/fi/pa165/monsterslayers/entities/User.java
@@ -1,7 +1,7 @@
 package cz.muni.fi.pa165.monsterslayers.entities;
 
-import cz.muni.fi.pa165.monsterslayers.entities.enums.RightsLevel;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.UserStatus;
+import cz.muni.fi.pa165.monsterslayers.enums.RightsLevel;
+import cz.muni.fi.pa165.monsterslayers.enums.UserStatus;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;

--- a/web-is-persistence/src/test/java/cz/muni/fi/pa165/monsterslayers/tests/HeroTests.java
+++ b/web-is-persistence/src/test/java/cz/muni/fi/pa165/monsterslayers/tests/HeroTests.java
@@ -1,34 +1,26 @@
 package cz.muni.fi.pa165.monsterslayers.tests;
 
-import cz.muni.fi.pa165.monsterslayers.dao.ClientRequestRepository;
 import cz.muni.fi.pa165.monsterslayers.dao.HeroRepository;
-import cz.muni.fi.pa165.monsterslayers.dao.MonsterTypeRepository;
 import cz.muni.fi.pa165.monsterslayers.dao.UserRepository;
-import cz.muni.fi.pa165.monsterslayers.entities.ClientRequest;
 import cz.muni.fi.pa165.monsterslayers.entities.Hero;
-import cz.muni.fi.pa165.monsterslayers.entities.MonsterType;
 import cz.muni.fi.pa165.monsterslayers.entities.User;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import javax.validation.ConstraintViolationException;
-import java.math.BigDecimal;
 import java.util.HashSet;
 
 /**
  * Test class for Hero entity
- * 
+ *
  * @author Maksym Tsuhui
  */
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/web-is-persistence/src/test/java/cz/muni/fi/pa165/monsterslayers/tests/JobRepositoryTest.java
+++ b/web-is-persistence/src/test/java/cz/muni/fi/pa165/monsterslayers/tests/JobRepositoryTest.java
@@ -8,7 +8,7 @@ import cz.muni.fi.pa165.monsterslayers.entities.ClientRequest;
 import cz.muni.fi.pa165.monsterslayers.entities.Hero;
 import cz.muni.fi.pa165.monsterslayers.entities.Job;
 import cz.muni.fi.pa165.monsterslayers.entities.User;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.JobStatus;
+import cz.muni.fi.pa165.monsterslayers.enums.JobStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/web-is-persistence/src/test/java/cz/muni/fi/pa165/monsterslayers/tests/MonsterTypeTest.java
+++ b/web-is-persistence/src/test/java/cz/muni/fi/pa165/monsterslayers/tests/MonsterTypeTest.java
@@ -3,7 +3,7 @@ package cz.muni.fi.pa165.monsterslayers.tests;
 import cz.muni.fi.pa165.monsterslayers.dao.MonsterTypeRepository;
 import cz.muni.fi.pa165.monsterslayers.entities.ClientRequest;
 import cz.muni.fi.pa165.monsterslayers.entities.MonsterType;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,13 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.ConstraintViolationException;
 import java.util.Arrays;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-
 /**
  * Test class for MonsterType.
  *

--- a/web-is-persistence/src/test/java/cz/muni/fi/pa165/monsterslayers/tests/UserTests.java
+++ b/web-is-persistence/src/test/java/cz/muni/fi/pa165/monsterslayers/tests/UserTests.java
@@ -1,29 +1,24 @@
 package cz.muni.fi.pa165.monsterslayers.tests;
 
-import cz.muni.fi.pa165.monsterslayers.dao.HeroRepository;
 import cz.muni.fi.pa165.monsterslayers.dao.UserRepository;
-import cz.muni.fi.pa165.monsterslayers.entities.Hero;
 import cz.muni.fi.pa165.monsterslayers.entities.User;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.RightsLevel;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.UserStatus;
+import cz.muni.fi.pa165.monsterslayers.enums.RightsLevel;
+import cz.muni.fi.pa165.monsterslayers.enums.UserStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.ConstraintViolationException;
-import java.util.HashSet;
 
 /**
  * Test class for User entity
- * 
+ *
  * @author Maksym Tsuhui
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -115,7 +110,7 @@ public class UserTests {
         user1.setEmail("other@email.cz");
         Assert.assertNotEquals(user, user1);
     }
-    
+
     @Test
     public void hashCodeTest() {
         User user1 = new User();

--- a/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/HeroService.java
+++ b/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/HeroService.java
@@ -2,9 +2,6 @@ package cz.muni.fi.pa165.monsterslayers.service;
 
 import cz.muni.fi.pa165.monsterslayers.entities.Hero;
 import cz.muni.fi.pa165.monsterslayers.entities.MonsterType;
-import cz.muni.fi.pa165.monsterslayers.entities.User;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
-import java.util.Collection;
 import org.springframework.stereotype.Service;
 
 /**

--- a/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/HeroServiceImpl.java
+++ b/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/HeroServiceImpl.java
@@ -1,11 +1,9 @@
 package cz.muni.fi.pa165.monsterslayers.service;
 
 import cz.muni.fi.pa165.monsterslayers.dao.HeroRepository;
-import cz.muni.fi.pa165.monsterslayers.dao.UserRepository;
 import cz.muni.fi.pa165.monsterslayers.entities.Hero;
 import cz.muni.fi.pa165.monsterslayers.entities.MonsterType;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.PowerElement;
-import java.util.Collection;
+import cz.muni.fi.pa165.monsterslayers.enums.PowerElement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/MappingService.java
+++ b/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/MappingService.java
@@ -1,16 +1,18 @@
 package cz.muni.fi.pa165.monsterslayers.service;
-import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 
 /**
  * Interface for bean mapping (used for mapping entities to data transfer objects)
- * 
+ *
  * @author Tomáš Richter
  */
 
 @Service
 public interface MappingService {
     <T> List<T> mapTo(Iterable<?> objects, Class<T> mapToClass);
+    <K, V> Map<K, V> mapTo(Map<?, V> objects, Class<K> mapToClass);
     <T> T mapTo(Object u, Class<T> mapToClass);
 }

--- a/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/MappingServiceImpl.java
+++ b/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/MappingServiceImpl.java
@@ -1,8 +1,7 @@
 package cz.muni.fi.pa165.monsterslayers.service;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -10,13 +9,13 @@ import org.dozer.Mapper;
 
 /**
  * Implementation of bean mapping service using Dozer framework.
- * 
+ *
  * @author Tomáš Richter
  */
 
 @Service
 public class MappingServiceImpl implements MappingService {
-    
+
     @Autowired
     private Mapper dozer;
 
@@ -27,6 +26,16 @@ public class MappingServiceImpl implements MappingService {
             mappedCollection.add(dozer.map(object, mapToClass));
         }
         return mappedCollection;
+    }
+
+    @Override
+    public <K, V> Map<K, V> mapTo(Map<?, V> objects, Class<K> mapToClass) {
+        Map<K, V> mappedMap = new HashMap<>();
+        for(Map.Entry<?, V> entry : objects.entrySet()){
+            mappedMap.put(dozer.map(entry.getKey(), mapToClass), entry.getValue());
+        }
+
+        return mappedMap;
     }
 
     @Override

--- a/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/UserServiceImpl.java
+++ b/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/UserServiceImpl.java
@@ -2,11 +2,10 @@ package cz.muni.fi.pa165.monsterslayers.service;
 
 import cz.muni.fi.pa165.monsterslayers.dao.UserRepository;
 import cz.muni.fi.pa165.monsterslayers.entities.User;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.RightsLevel;
-import cz.muni.fi.pa165.monsterslayers.entities.enums.UserStatus;
+import cz.muni.fi.pa165.monsterslayers.enums.RightsLevel;
+import cz.muni.fi.pa165.monsterslayers.enums.UserStatus;
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.Collection;
 import java.util.List;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;

--- a/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/facadeImpl/ClientRequestFacadeImpl.java
+++ b/web-is-service/src/main/java/cz/muni/fi/pa165/monsterslayers/service/facadeImpl/ClientRequestFacadeImpl.java
@@ -3,6 +3,7 @@ package cz.muni.fi.pa165.monsterslayers.service.facadeImpl;
 import cz.muni.fi.pa165.monsterslayers.dto.ClientRequestDTO;
 import cz.muni.fi.pa165.monsterslayers.dto.CreateClientRequestDTO;
 import cz.muni.fi.pa165.monsterslayers.entities.ClientRequest;
+import cz.muni.fi.pa165.monsterslayers.entities.MonsterType;
 import cz.muni.fi.pa165.monsterslayers.facade.ClientRequestFacade;
 import cz.muni.fi.pa165.monsterslayers.service.ClientRequestService;
 import cz.muni.fi.pa165.monsterslayers.service.MappingService;
@@ -67,7 +68,7 @@ public class ClientRequestFacadeImpl implements ClientRequestFacade {
         clientRequest.setReward(createClientRequestDTO.getReward());
         clientRequest.setTitle(createClientRequestDTO.getTitle());
         clientRequest.setClient(userService.findUserById(createClientRequestDTO.getClientId()));
-        clientRequest.setKillList(createClientRequestDTO.getKillList());
+        clientRequest.setKillList(mappingService.mapTo(createClientRequestDTO.getKillList(), MonsterType.class));
         clientRequestService.saveClientRequest(clientRequest);
     }
 }


### PR DESCRIPTION
Persistence now depends on API and not vice versa. Enums were moved to
API layer, DTOs depends only on another DTOs, not on Entities. Mapping
fuction for Map objects has been added.